### PR TITLE
update Kitura-net- remove minor version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "SimpleHttpClient",
 	dependencies:[
 		.Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", majorVersion: 0, minor: 4),
-		.Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 1, minor: 1)
+		.Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 1)
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "SimpleHttpClient",
 	dependencies:[
 		.Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", majorVersion: 0, minor: 4),
-		.Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 1)
+		.Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 1, minor: 6)
 	]
 )


### PR DESCRIPTION
This builds as-is with only the majorVersion.  If you want to keep the minor version, it needs to be updated to `minor: 6`

fyi: @rfdickerson