### PR TITLE
Update KituraNet to 2.1 & Update Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 env:
   global:
   - SWIFT_VERSION=3.1.1
-  - SWIFT_VERSION=4.0.3
+  - SWIFT_VERSION=4.1
 
 notifications:
   email:
@@ -18,7 +18,7 @@ sudo: required
 
 dist: trusty
 
-osx_image: xcode9.2
+osx_image: xcode9.3
 
 before_install:
     - rvm install 2.4.0

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies:[
         .package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-logger-swift.git", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .upToNextMinor(from: "2.0.0")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target defines a module or a test suite.

--- a/Tests/SimpleHttpClientTests/HttpClientTest.swift
+++ b/Tests/SimpleHttpClientTests/HttpClientTest.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import SimpleHttpClient
 
 class HttpClientTests: XCTestCase {
-	private static let httpbinHost = "httpbin.mybluemix.net"
+	private static let httpbinHost = "httpbin.org"
 	private static let testString = "TestDataSimpleHttpClient"
 
 	let httpResource = HttpResource(schema: "http", host: httpbinHost, port: "80")


### PR DESCRIPTION
In the release of Kitura 2.3, the KituraNet version got updated to `2.1` which led to this PR whilst updating the generator to have Kitura 2.3